### PR TITLE
Fix for missing sessionToken after signup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,9 @@ export async function init() {
 
       await user_c.signUp();
 
-      return { ...user, session: user_c.getSessionToken() };
+      const user_b = await Parse.User.logIn(user.username, token);
+
+      return { ...user, session: user_b.getSessionToken() };
     } catch (error) {
       console.error(error);
 


### PR DESCRIPTION
Fixed a problem I was facing where the signed up user did not have a valid sessionToken which lead to a failed authentication for the first login of an LDAP user. 
Explicitly log in the user is a work around and makes sure that the session token exists.